### PR TITLE
1. getPageElements - now returns an empty list instead of throwing an…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>com.slickqa</groupId>
     <artifactId>slick-webdriver-java</artifactId>
     <packaging>jar</packaging>
-    <version>1.0.0-18</version>
+    <version>1.0.0-19</version>
     <name>Slick Webdriver for Java</name>
     <description>This is a wrapper and utilities for using webdriver / selenium in Java.</description>
 

--- a/src/main/java/com/slickqa/webdriver/Descendant.java
+++ b/src/main/java/com/slickqa/webdriver/Descendant.java
@@ -1,0 +1,40 @@
+package com.slickqa.webdriver;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.NoSuchElementException;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+
+import java.util.List;
+
+/**
+ *
+ * @author slambson
+ */
+public class Descendant implements RelativeElement
+{
+	private PageElement descendant;
+
+	public Descendant(PageElement descendant)
+	{
+		this.descendant = descendant;
+	}
+
+	public Descendant(By finder) {
+		this.descendant = new PageElement("Descendant FindBy: " + finder.toString(), finder);
+	}
+
+	@Override
+	public WebElement findElement(WebDriver browser, PageElement item, String tagName) throws NoSuchElementException
+	{
+		// fail fast, the descendant element will handle the timing
+		WebElement relativeElement = descendant.getElement(browser, 0);
+		return relativeElement.findElement(By.xpath("ancestor::" + tagName));
+	}
+
+	@Override
+	public String getFindByDescription()
+	{
+		return "Relative descendant element found " + descendant.getFindByDescription();
+	}
+}

--- a/src/main/java/com/slickqa/webdriver/FindBy.java
+++ b/src/main/java/com/slickqa/webdriver/FindBy.java
@@ -1,13 +1,7 @@
 package com.slickqa.webdriver;
 
-import com.slickqa.webdriver.finders.FindByHref;
-import com.slickqa.webdriver.finders.FindByHrefContains;
-import com.slickqa.webdriver.finders.FindBySrcContains;
-import com.slickqa.webdriver.finders.FindByValue;
+import com.slickqa.webdriver.finders.*;
 import org.openqa.selenium.By;
-import com.slickqa.webdriver.finders.FindByAlt;
-import com.slickqa.webdriver.finders.FindBySrc;
-import com.slickqa.webdriver.finders.FindByAttributeValue;
 
 /**
  * FindBy just extends the selenium By class adding some additional finders for locating PageElements
@@ -85,7 +79,7 @@ public abstract class FindBy extends By
 	}
 
 	/**
-	 * Find an input by a specified attributes values.  This must match exactly.
+	 * Find an element by a specified attributes values.  This must match exactly.
 	 *
 	 * @param attribute The attribute of the page element to look for
 	 * @param value The value of the attribute to locate the page element
@@ -94,6 +88,17 @@ public abstract class FindBy extends By
 	public static By attributeValue(String attribute, String value)
 	{
 		return new FindByAttributeValue(attribute, value);
+	}
+
+	/**
+	 * Find an element by the specified text.  This must match exactly.
+	 *
+	 * @param text The text inside the page element you want to locate
+	 * @return a By instance that finds web elements in web driver.
+	 */
+	public static By text(String text)
+	{
+		return new FindByText(text);
 	}
 }
 

--- a/src/main/java/com/slickqa/webdriver/FollowedBySibling.java
+++ b/src/main/java/com/slickqa/webdriver/FollowedBySibling.java
@@ -1,0 +1,39 @@
+package com.slickqa.webdriver;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.NoSuchElementException;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+
+/**
+ *
+ * @author slambson
+ */
+public class FollowedBySibling implements RelativeElement
+{
+	private PageElement followingSibling;
+	private String tagName;
+
+	public FollowedBySibling(PageElement followingSibling)
+	{
+		this.followingSibling = followingSibling;
+	}
+
+	public FollowedBySibling(By finder) {
+		this.followingSibling = new PageElement("Followed By Sibling FindBy: " + finder.toString(), finder);
+	}
+
+	@Override
+	public WebElement findElement(WebDriver browser, PageElement item, String tagName) throws NoSuchElementException
+	{
+		// fail fast, the child element will handle the timing
+		WebElement relativeElement = followingSibling.getElement(browser, 0);
+		return relativeElement.findElement(By.xpath("preceding-sibling::" + tagName));
+	}
+
+	@Override
+	public String getFindByDescription()
+	{
+		return "Relative child element found " + followingSibling.getFindByDescription();
+	}
+}

--- a/src/main/java/com/slickqa/webdriver/PrecededBySibling.java
+++ b/src/main/java/com/slickqa/webdriver/PrecededBySibling.java
@@ -1,0 +1,38 @@
+package com.slickqa.webdriver;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.NoSuchElementException;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+
+/**
+ *
+ * @author slambson
+ */
+public class PrecededBySibling implements RelativeElement
+{
+	private PageElement precedingSibling;
+
+	public PrecededBySibling(PageElement precedingSibling)
+	{
+		this.precedingSibling = precedingSibling;
+	}
+
+	public PrecededBySibling(By finder) {
+		this.precedingSibling = new PageElement("Preceded By Sibling FindBy: " + finder.toString(), finder);
+	}
+
+	@Override
+	public WebElement findElement(WebDriver browser, PageElement item, String tagName) throws NoSuchElementException
+	{
+		// fail fast, the child element will handle the timing
+		WebElement relativeElement = precedingSibling.getElement(browser, 0);
+		return relativeElement.findElement(By.xpath("following-sibling::" + tagName));
+	}
+
+	@Override
+	public String getFindByDescription()
+	{
+		return "Relative child element found " + precedingSibling.getFindByDescription();
+	}
+}

--- a/src/main/java/com/slickqa/webdriver/Relative.java
+++ b/src/main/java/com/slickqa/webdriver/Relative.java
@@ -1,0 +1,35 @@
+package com.slickqa.webdriver;
+
+import org.openqa.selenium.By;
+
+/**
+ *
+ * @author slambson
+ */
+public class Relative
+{
+	public static RelativeElement Decendent(PageElement decendent)
+	{
+		return new Descendant(decendent);
+	}
+
+	public static RelativeElement Decendent(By finder) {
+		return new Descendant(finder);
+	}
+
+	public static RelativeElement PrecededBySibling(PageElement precededBySibling) {
+		return new PrecededBySibling(precededBySibling);
+	}
+
+	public static RelativeElement PrecededBySibling(By finder) {
+		return new PrecededBySibling(finder);
+	}
+
+	public static RelativeElement FollowedBySibling(PageElement followedBySibling) {
+		return new FollowedBySibling(followedBySibling);
+	}
+
+	public static RelativeElement FollowedBySibling(By finder) {
+		return new FollowedBySibling(finder);
+	}
+}

--- a/src/main/java/com/slickqa/webdriver/RelativeElement.java
+++ b/src/main/java/com/slickqa/webdriver/RelativeElement.java
@@ -1,0 +1,14 @@
+package com.slickqa.webdriver;
+
+import org.openqa.selenium.NoSuchElementException;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+
+import java.util.List;
+
+public interface RelativeElement
+{
+	public WebElement findElement(WebDriver browser, PageElement pageElement, String tagName) throws NoSuchElementException;
+
+	public String getFindByDescription();
+}

--- a/src/main/java/com/slickqa/webdriver/finders/FindByText.java
+++ b/src/main/java/com/slickqa/webdriver/finders/FindByText.java
@@ -1,0 +1,41 @@
+
+package com.slickqa.webdriver.finders;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+/**
+ *
+ * @author slambson
+ */
+public class FindByText extends AbstractFindByParentBy
+{
+	String text;
+
+	public FindByText(String text)
+	{
+		this.text = text;
+	}
+
+	@Override
+	public String toString()
+	{
+		return String.format("By text '%s'.", text);
+	}
+
+	@Override
+	public boolean matches(WebElement e)
+	{
+		String textValue = e.getText();
+		return textValue != null && textValue.equals(text);
+	}
+
+	@Override
+	public ArrayList<By> getParentBy()
+	{
+		return new ArrayList<By>(Arrays.asList(tagName("label"), tagName("div"), tagName("h1"), tagName("h2"), tagName("h3")));
+	}
+}

--- a/src/test/java/com/slickqa/webdriver/PageElementExampleTests.java
+++ b/src/test/java/com/slickqa/webdriver/PageElementExampleTests.java
@@ -1,6 +1,5 @@
 package com.slickqa.webdriver;
 
-import io.github.bonigarcia.wdm.FirefoxDriverManager;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.remote.DesiredCapabilities;
 import org.testng.annotations.*;
@@ -40,14 +39,14 @@ public class PageElementExampleTests {
     }
 
     /**
-     * The list of input page elements returned should be 4
+     * The list of input page elements returned should be 8
      */
     @Test
     public void findListOfPageElementsTest() {
         browserWrapper.goTo(testPage);
         SlickWebDriverExamplePage slickWebDriverExamplePage = new SlickWebDriverExamplePage(browserWrapper);
         int numberOfElementsFound = slickWebDriverExamplePage.listInputElements();
-        softAssert.assertEquals(numberOfElementsFound, 5, "Incorrect number of input elements found on page");
+        softAssert.assertEquals(numberOfElementsFound, 8, "Incorrect number of input elements found on page");
         softAssert.assertAll();
     }
 
@@ -217,6 +216,195 @@ public class PageElementExampleTests {
 
         softAssert.assertAll();
     }
+
+    /**
+     * Test get element relative to child element
+     */
+    @Test
+    public void getElementRelativeToChildElement() {
+        browserWrapper.goTo(testPage);
+        SlickWebDriverExamplePage slickWebDriverExamplePage = new SlickWebDriverExamplePage(browserWrapper);
+        PageElement relativeChildElement = new PageElement("Relative Child Element", FindBy.id("descendent-label-element"));
+
+        PageElement ascendantTable = new PageElement("parent element div tag", Relative.Decendent(relativeChildElement), "table");
+        String verify2 = browserWrapper.getAttribute(ascendantTable, "data-qa");
+        softAssert.assertEquals(verify2, "great-3-grand-parent", "Did not get element relative to child element");
+
+        PageElement ascendantTbody = new PageElement(Relative.Decendent(relativeChildElement), "tbody");
+        String verify3 = browserWrapper.getAttribute(ascendantTbody, "data-qa");
+        softAssert.assertEquals(verify3, "great-2-parent", "Did not get element relative to child element");
+
+        PageElement ascendantTr = new PageElement("parent element div tag", Relative.Decendent(relativeChildElement), "tr");
+        String verify4 = browserWrapper.getAttribute(ascendantTr, "data-qa");
+        softAssert.assertEquals(verify4, "great-grand-parent", "Did not get element relative to child element");
+
+        PageElement ascendantTd = new PageElement("parent element div tag", Relative.Decendent(relativeChildElement), "td");
+        String verify5 = browserWrapper.getAttribute(ascendantTd, "data-qa");
+        softAssert.assertEquals(verify5, "grand-parent", "Did not get element relative to child element");
+
+        PageElement ascendantA = new PageElement("parent element a tag", Relative.Decendent(relativeChildElement), "a");
+        String verify6 = browserWrapper.getAttribute(ascendantA, "data-qa");
+        softAssert.assertEquals(verify6, "parent", "Did not get element relative to child element");
+
+        softAssert.assertAll();
+    }
+
+    /**
+     * Test get element relative to child FindBy
+     */
+    @Test
+    public void getElementRelativeToChildFindBy() {
+        browserWrapper.goTo(testPage);
+
+        PageElement ascendantTable = new PageElement("parent element div tag", Relative.Decendent(FindBy.id("descendent-label-element")), "table");
+        String verify2 = browserWrapper.getAttribute(ascendantTable, "data-qa");
+        softAssert.assertEquals(verify2, "great-3-grand-parent", "Did not get element relative to child element");
+
+        PageElement ascendantTbody = new PageElement(Relative.Decendent(FindBy.id("descendent-label-element")), "tbody");
+        String verify3 = browserWrapper.getAttribute(ascendantTbody, "data-qa");
+        softAssert.assertEquals(verify3, "great-2-parent", "Did not get element relative to child element");
+
+        PageElement ascendantTr = new PageElement("parent element div tag", Relative.Decendent(FindBy.id("descendent-label-element")), "tr");
+        String verify4 = browserWrapper.getAttribute(ascendantTr, "data-qa");
+        softAssert.assertEquals(verify4, "great-grand-parent", "Did not get element relative to child element");
+
+        PageElement ascendantTd = new PageElement("parent element div tag", Relative.Decendent(FindBy.id("descendent-label-element")), "td");
+        String verify5 = browserWrapper.getAttribute(ascendantTd, "data-qa");
+        softAssert.assertEquals(verify5, "grand-parent", "Did not get element relative to child element");
+
+        PageElement ascendantA = new PageElement("parent element a tag", Relative.Decendent(FindBy.id("descendent-label-element")), "a");
+        String verify6 = browserWrapper.getAttribute(ascendantA, "data-qa");
+        softAssert.assertEquals(verify6, "parent", "Did not get element relative to child element");
+
+        softAssert.assertAll();
+    }
+
+    /**
+     * Test get element relative to preceding sibling element
+     */
+    @Test
+    public void getElementRelativeToPrecedBySiblingElement() {
+        browserWrapper.goTo(testPage);
+        PageElement precedingSiblingElement = new PageElement("Preceding Sibling Element", FindBy.text("This Is A Label"));
+
+        PageElement precededByA = new PageElement("preceded by sibling a tag", Relative.PrecededBySibling(precedingSiblingElement), "a");
+        String verify1 = browserWrapper.getAttribute(precededByA, "data-qa");
+        softAssert.assertEquals(verify1, "following-sibling-element-a", "Did not get element relative to preceding sibling element");
+
+        PageElement precededByInput = new PageElement(Relative.PrecededBySibling(precedingSiblingElement), "input");
+        String verify2 = browserWrapper.getAttribute(precededByInput, "data-qa");
+        softAssert.assertEquals(verify2, "following-sibling-element-input", "Did not get element relative to preceding sibling element");
+
+        PageElement precededByLabel = new PageElement("preceded by sibling a tag", Relative.PrecededBySibling(precedingSiblingElement), "label");
+        String verify3 = browserWrapper.getAttribute(precededByLabel, "data-qa");
+        softAssert.assertEquals(verify3, "following-sibling-element-label", "Did not get element relative to preceding sibling element");
+
+        softAssert.assertAll();
+    }
+
+    /**
+     * Test get element relative to preceding sibling FindBy
+     */
+    @Test
+    public void getElementRelativeToPrecededBySiblingFindBy() {
+        browserWrapper.goTo(testPage);
+
+        PageElement precededByA = new PageElement(Relative.PrecededBySibling(FindBy.text("This Is A Label")), "a");
+        String verify1 = browserWrapper.getAttribute(precededByA, "data-qa");
+        softAssert.assertEquals(verify1, "following-sibling-element-a", "Did not get element relative to preceding sibling element");
+
+        PageElement precededByInput = new PageElement("preceded by sibling a tag", Relative.PrecededBySibling(FindBy.text("This Is A Label")), "input");
+        String verify2 = browserWrapper.getAttribute(precededByInput, "data-qa");
+        softAssert.assertEquals(verify2, "following-sibling-element-input", "Did not get element relative to preceding sibling element");
+
+        PageElement precededByLabel = new PageElement("preceded by sibling a tag", Relative.PrecededBySibling(FindBy.text("This Is A Label")), "label");
+        String verify3 = browserWrapper.getAttribute(precededByLabel, "data-qa");
+        softAssert.assertEquals(verify3, "following-sibling-element-label", "Did not get element relative to preceding sibling element");
+
+        softAssert.assertAll();
+    }
+
+    /**
+     * Test get element relative to following sibling element
+     */
+    @Test
+    public void getElementRelativeToFollowedBySiblingElement() {
+        browserWrapper.goTo(testPage);
+        PageElement followingSiblingElement = new PageElement("Following Sibling Element", FindBy.text("This Is A Label"));
+
+        PageElement followingElementInput = new PageElement("following sibling input tag", Relative.FollowedBySibling(followingSiblingElement), "input");
+        String verify1 = browserWrapper.getAttribute(followingElementInput, "data-qa");
+        softAssert.assertEquals(verify1, "preceding-sibling-element-input", "Did not get element relative to preceding sibling element");
+
+        PageElement followingElementLabel = new PageElement("following sibling label label", Relative.FollowedBySibling(followingSiblingElement), "label");
+        String verify2 = browserWrapper.getAttribute(followingElementLabel, "data-qa");
+        softAssert.assertEquals(verify2, "preceding-sibling-element-label", "Did not get element relative to preceding sibling element");
+
+        PageElement followingElementA = new PageElement(Relative.FollowedBySibling(followingSiblingElement), "a");
+        String verify3 = browserWrapper.getAttribute(followingElementA, "data-qa");
+        softAssert.assertEquals(verify3, "preceding-sibling-element-a", "Did not get element relative to preceding sibling element");
+
+        softAssert.assertAll();
+    }
+
+    /**
+     * Test get element relative to following sibling element
+     */
+    @Test
+    public void getElementRelativeToFollowedBySiblingFindBy() {
+        browserWrapper.goTo(testPage);
+
+        PageElement followingElementInput = new PageElement("following sibling input tag", Relative.FollowedBySibling(FindBy.text("This Is A Label")), "input");
+        String verify1 = browserWrapper.getAttribute(followingElementInput, "data-qa");
+        softAssert.assertEquals(verify1, "preceding-sibling-element-input", "Did not get element relative to preceding sibling element");
+
+        PageElement followingElementLabel = new PageElement(Relative.FollowedBySibling(FindBy.text("This Is A Label")), "label");
+        String verify2 = browserWrapper.getAttribute(followingElementLabel, "data-qa");
+        softAssert.assertEquals(verify2, "preceding-sibling-element-label", "Did not get element relative to preceding sibling element");
+
+        PageElement followingElementA = new PageElement("following sibling label a", Relative.FollowedBySibling(FindBy.text("This Is A Label")), "a");
+        String verify3 = browserWrapper.getAttribute(followingElementA, "data-qa");
+        softAssert.assertEquals(verify3, "preceding-sibling-element-a", "Did not get element relative to preceding sibling element");
+
+        softAssert.assertAll();
+    }
+
+    /**
+     * Test get element by text
+     */
+    @Test
+    public void getElementByText() {
+        browserWrapper.goTo(testPage);
+
+        PageElement labelByText = new PageElement("label element by text", FindBy.text("Get Label Element By Text"));
+        String verify1 = browserWrapper.getAttribute(labelByText, "data-qa");
+        softAssert.assertEquals(verify1, "label-element-by-text", "Did not get element relative to preceding sibling element");
+
+        PageElement divByText = new PageElement("div element by text", FindBy.text("Get Div Element By Text"));
+        String verify2 = browserWrapper.getAttribute(divByText, "data-qa");
+        softAssert.assertEquals(verify2, "div-element-by-text", "Did not get element relative to preceding sibling element");
+
+        PageElement h3ByText = new PageElement("h3 element by text", FindBy.text("Get H3 Element By Text"));
+        String verify3 = browserWrapper.getAttribute(h3ByText, "data-qa");
+        softAssert.assertEquals(verify3, "h3-element-by-text", "Did not get element relative to preceding sibling element");
+
+        softAssert.assertAll();
+    }
+
+    @Test
+    public void getElementClasses() {
+        browserWrapper.goTo(testPage);
+
+        PageElement label = new PageElement(FindBy.id("label-with-class"));
+        String text = browserWrapper.getText(label);
+        String elementClasses = browserWrapper.getAttribute(label, "class");
+
+        softAssert.assertEquals(text, "5-Year");
+        softAssert.assertEquals(elementClasses, "selected");
+
+        softAssert.assertAll();
+    }
+
 
     @AfterSuite
     public void cleanup() {


### PR DESCRIPTION
… exception if no elements are found matching the specified findby.  If looking for a single element no elements are found matching the findby then the NoSuchElementException is still thrown

	This keeps the behavior more in line with web driver findElement and findElements behavior
2. FindBy.text - can locate a label or a div element based on the text contained in the
3. Relative.FollowedBySiblingElement
	PageElement followingElementLabel = new PageElement(Relative.FollowedBySiblingElement(FindBy.linkText("This Is A Label")), "label");
4. Relative.PrecededBySiblingElement
5. Relative.DecendentElement