### PR TITLE
Sometimes if the element is in motion (I believe) clicking on an elem…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>com.slickqa</groupId>
     <artifactId>slick-webdriver-java</artifactId>
     <packaging>jar</packaging>
-    <version>1.0.0-21</version>
+    <version>1.0.0-22</version>
     <name>Slick Webdriver for Java</name>
     <description>This is a wrapper and utilities for using webdriver / selenium in Java.</description>
 

--- a/src/main/java/com/slickqa/webdriver/DefaultWebDriverWrapper.java
+++ b/src/main/java/com/slickqa/webdriver/DefaultWebDriverWrapper.java
@@ -223,6 +223,16 @@ public class DefaultWebDriverWrapper implements WebDriverWrapper {
             } catch (StaleElementReferenceException e) {
                 logger.warn("Got a stale element exception trying to click, retrying.", e);
             }
+            catch (Exception e) {
+                if (e.getMessage().contains("not clickable at point")) {
+                    logger.warn("Got a 'not clickable at point' exception clicking, retrying.");
+                    try {
+                        Thread.sleep(500);
+                    } catch (Exception te) {
+
+                    }
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Sometimes if the element is in motion (I believe) clicking on an element throws an exception "not clickable at location".

We didn't see this too often but with the latest (version 61) of Chrome we see it a lot, especially if the element is not within the current view in the browser and webdriver has to scroll down the page to get to the item.  We are already retrying on a stale element exception so I didn't think it was too much of a stretch to retry on this exception as well.