### PR TITLE
there were some cases where the element was found and then went away …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>com.slickqa</groupId>
     <artifactId>slick-webdriver-java</artifactId>
     <packaging>jar</packaging>
-    <version>1.0.0-35</version>
+    <version>1.0.0-36</version>
     <name>Slick Webdriver for Java</name>
     <description>This is a wrapper and utilities for using webdriver / selenium in Java.</description>
 

--- a/resources/examplePage.html
+++ b/resources/examplePage.html
@@ -244,5 +244,7 @@
     }
 </script>
 
+<input id="hiddenElement" type="hidden">
+
 </body>
 </html>

--- a/src/test/java/com/slickqa/webdriver/PageElementExampleTests.java
+++ b/src/test/java/com/slickqa/webdriver/PageElementExampleTests.java
@@ -2,7 +2,9 @@ package com.slickqa.webdriver;
 
 import io.github.bonigarcia.wdm.DriverManagerType;
 import io.github.bonigarcia.wdm.FirefoxDriverManager;
+import org.apache.commons.lang3.time.StopWatch;
 import org.openqa.selenium.Cookie;
+import org.openqa.selenium.ElementNotVisibleException;
 import org.openqa.selenium.Keys;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.chrome.ChromeOptions;
@@ -17,6 +19,8 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+import java.util.Timer;
+import java.util.concurrent.TimeUnit;
 
 
 /**
@@ -145,6 +149,19 @@ public class PageElementExampleTests {
         softAssert.assertEquals(browserWrapper.getPageUrl(), "http://www.slickqa.com/features.html", "We did not end up on the correct end page so we must have clicked on the wrong link");
         softAssert.assertAll();
     }
+
+    @Test
+    public void clickElementInParentElementChildByXpath() {
+        browserWrapper.goTo(getExamplePagePath());
+        SlickWebDriverExamplePage slickWebDriverExamplePage = new SlickWebDriverExamplePage(browserWrapper);
+        slickWebDriverExamplePage.clickOnElementByXpath();
+        Assert.assertTrue(browserWrapper.getPageUrl().endsWith("/resources/invalid"), "We did not end up on the correct end page so we must not have clicked on the link correctly");
+        browserWrapper.goBack();
+        slickWebDriverExamplePage.clickOnElementInParentElementChildByXpath();
+        softAssert.assertEquals(browserWrapper.getPageUrl(), "http://www.slickqa.com/features.html", "We did not end up on the correct end page so we must have clicked on the wrong link");
+        softAssert.assertAll();
+    }
+
 
     /**
      * Test that clicking on an element within a Parent where the Parent is defined with a FindBy works
@@ -846,6 +863,44 @@ public class PageElementExampleTests {
         browserWrapper.click(button);
         Assert.assertTrue(browserWrapper.exists(orFinderElement), "Element should be found by class three");
         Assert.assertEquals(browserWrapper.getAttribute(orFinderElement, "class"), "three");
+    }
+
+    @Test
+    public void WaitForNotVisible() {
+        SoftAssert softAssert = new SoftAssert();
+
+        browserWrapper.goTo(getExamplePagePath());
+        SlickWebDriverExamplePage examplePage = new SlickWebDriverExamplePage(browserWrapper);
+        examplePage.waitDefaultTimeForElementThatExists();
+        StopWatch stopWatch = new StopWatch();
+        stopWatch.start();
+        boolean gotCorrectException = false;
+        try {
+            examplePage.waitPassedInTimeForElementToNotBeVisibleElementExists(2);
+        } catch (ElementNotVisibleException e) {
+            gotCorrectException = true;
+        }
+        stopWatch.stop();
+        int duration = (int) stopWatch.getTime(TimeUnit.SECONDS);
+        softAssert.assertTrue(Math.round(duration) <= 2, "The duration was not what we expected when element did not go away.  Duration was: " + duration);
+        softAssert.assertTrue(gotCorrectException, "We did not get the correct exception");
+
+        stopWatch.reset();
+        stopWatch.start();
+        examplePage.waitPassedInTimeForElementToNotBeVisibleElementDoesNotExists(2);
+        stopWatch.stop();
+        int duration2 = (int) stopWatch.getTime(TimeUnit.SECONDS);
+        softAssert.assertTrue(Math.round(duration2) <= 2, "The duration was not what we expected when element did not exist.  Duration was: " + duration);
+
+
+        stopWatch.reset();
+        stopWatch.start();
+        examplePage.waitPassedInTimeForElementToNotBeVisibleElementIsHidden(2);
+        stopWatch.stop();
+        int duration3 = (int) stopWatch.getTime(TimeUnit.SECONDS);
+        softAssert.assertTrue(Math.round(duration3) <= 2, "The duration was not what we expected when element did not exist.  Duration was: " + duration);
+
+        softAssert.assertAll();
     }
 
 

--- a/src/test/java/com/slickqa/webdriver/SlickWebDriverExamplePage.java
+++ b/src/test/java/com/slickqa/webdriver/SlickWebDriverExamplePage.java
@@ -18,12 +18,15 @@ public class SlickWebDriverExamplePage {
     private PageElement childElements1 = new PageElement("Child Elements", In.ParentElement(parentElement1), FindBy.tagName("a"));
     private PageElement parentElement2 = new PageElement("Parent Element", FindBy.attributeValue("data-qa", "parent-div"));
     private PageElement childElements2 = new PageElement("Child Elements", In.ParentElement(parentElement2), FindBy.id("features-link"));
+    private PageElement elements2ByXpath = new PageElement("Child Elements", FindBy.xpath("//*[@id=\"features-link\"]"));
+    private PageElement childElements2ByXpath = new PageElement("Child Elements", In.ParentElement(parentElement2), FindBy.xpath("*[@id=\"features-link\"]"));
     private PageElement inputElements = new PageElement("input elements", FindBy.tagName("input"));
     private PageElement childElementWithFindByParent = new PageElement("Child element with findby parent", In.ParentElement(FindBy.attributeValue("data-qa", "parent-div")), FindBy.id("features-link"));
     private PageElement childElements3 = new PageElement("Child Elements in Parent specified with FindBy", In.ParentElement(FindBy.className("sidenav-inner")), FindBy.tagName("a"));
     private PageElement childElementByIndex = new PageElement("Child Element by index", In.ParentElement(parentElement1), FindBy.tagName("a"), 6);
     private PageElement sliderRates = new PageElement("Rates slider", FindBy.id("product-slider"));
     private PageElement invalidElement = new PageElement("Invalid element", FindBy.id("product-slidera"));
+    private PageElement hiddenElement = new PageElement("Hidden element", FindBy.id("hiddenElement"));
 
     private WebDriverWrapper browserWrapper;
 
@@ -75,6 +78,14 @@ public class SlickWebDriverExamplePage {
         browserWrapper.click(childElements2);
     }
 
+    public void clickOnElementInParentElementChildByXpath() {
+        browserWrapper.click(childElements2ByXpath);
+    }
+
+    public void clickOnElementByXpath() {
+        browserWrapper.click(elements2ByXpath);
+    }
+
     public void clickOnElementInParentElementWithFindBy() {
         browserWrapper.click(childElementWithFindByParent);
     }
@@ -118,5 +129,17 @@ public class SlickWebDriverExamplePage {
 
     public void waitPassedInTimeForElementThatDoesNotExists(int timeout) {
         browserWrapper.waitFor(invalidElement, timeout);
+    }
+
+    public void waitPassedInTimeForElementToNotBeVisibleElementExists(int timeout) {
+        browserWrapper.waitForNotVisible(sliderRates, timeout);
+    }
+
+    public void waitPassedInTimeForElementToNotBeVisibleElementDoesNotExists(int timeout) {
+        browserWrapper.waitForNotVisible(invalidElement, timeout);
+    }
+
+    public void waitPassedInTimeForElementToNotBeVisibleElementIsHidden(int timeout) {
+        browserWrapper.waitForNotVisible(hiddenElement, timeout);
     }
 }


### PR DESCRIPTION
…before we could wait for it to be invisible so then it was throwing a stale element exception and it would continue to do that for the default timeout.  This will try and re-fetch the element if we get a stale element exception.